### PR TITLE
Make typeahead sort-- promoting identical matches, falling back to naturally.

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,15 +1,28 @@
 $( document ).ready(function() {
 	var typer = $('.typeahead');
-
 	var genders = new Bloodhound({
 		datumTokenizer: Bloodhound.tokenizers.whitespace,
 		queryTokenizer: Bloodhound.tokenizers.whitespace,
-		prefetch: 'https://raw.githubusercontent.com/anne-decusatis/genderamender/master/genders.json'
+		prefetch: 'https://raw.githubusercontent.com/anne-decusatis/genderamender/master/genders.json',
+        sorter: function(a, b) {
+            var i = typer.val().toLowerCase();
+
+            // If there's a complete match it wins.
+            if(i == a) { return -1; }
+            else if (i == b) { return  1; }
+
+            // Otherwise just sort it naturally.
+            else if (a < b) { return -1; }
+            else if (a > b) { return  1; }
+            else return 0;
+        }
 	});
+
 	typer.typeahead({
 		hint: true,
 		highlight: true,
 		minLength: 1
+
 	},
 	{
 		name: 'genders',


### PR DESCRIPTION
This adds some basic sorting logic to the Bloodhound search. For example, previously if you typed in 'Male' the immediate choice below would be 'female to male' with 'male' being the second.  This sort will promote identical matches to be the first choice.  In addition, it'll just naturally sort the remainder of matches so the JSON data doesn't need to be presorted.
