### PR TITLE
Correct omission of "attack helicopter" gender identity.

### DIFF
--- a/genders/en-US.json
+++ b/genders/en-US.json
@@ -3,6 +3,7 @@
   "agender": 3, 
   "androgyne": 0, 
   "androgynous": 0, 
+  "attack helicopter": 0, 
   "bigender": 3, 
   "cis": 0, 
   "cisgender": 0, 


### PR DESCRIPTION
No distinction is made between attack helicopters with coaxial rotors such as
the Ka-50 Black Shark vs the AH-64 Apache's tail rotor design, but this should
not be interpreted as the author's rejection of the importance of this
to attack helicopters.  Future work should allow for specifying these details
as well as armament and operational range which determines who an attack
helicopter engages with.
